### PR TITLE
fix: keep task logger messages static

### DIFF
--- a/app/api/tasks/[taskId]/continue/route.ts
+++ b/app/api/tasks/[taskId]/continue/route.ts
@@ -219,7 +219,7 @@ async function continueTask(
           installDependencies,
           preDeterminedBranchName: branchName, // Use existing branch
           onProgress: async (progress: number, message: string) => {
-            await logger.updateProgress(progress, message)
+            await logger.updateProgress(progress, 'Sandbox setup in progress')
           },
         },
         logger,

--- a/app/api/tasks/[taskId]/restart-dev/route.ts
+++ b/app/api/tasks/[taskId]/restart-dev/route.ts
@@ -149,11 +149,7 @@ export default mergeConfig(userConfig, defineConfig({
 
     const captureServerStdout = new Writable({
       write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
-        const lines = chunk
-          .toString()
-          .split('\n')
-          .filter((line) => line.trim())
-        for (const line of lines) {
+        if (chunk.toString().trim()) {
           logger.info('Development server produced output').catch(() => {})
         }
         callback()
@@ -162,11 +158,7 @@ export default mergeConfig(userConfig, defineConfig({
 
     const captureServerStderr = new Writable({
       write(chunk: Buffer | string, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
-        const lines = chunk
-          .toString()
-          .split('\n')
-          .filter((line) => line.trim())
-        for (const line of lines) {
+        if (chunk.toString().trim()) {
           logger.info('Development server produced output').catch(() => {})
         }
         callback()

--- a/app/api/tasks/[taskId]/restart-dev/route.ts
+++ b/app/api/tasks/[taskId]/restart-dev/route.ts
@@ -154,7 +154,7 @@ export default mergeConfig(userConfig, defineConfig({
           .split('\n')
           .filter((line) => line.trim())
         for (const line of lines) {
-          logger.info(`[SERVER] ${line}`).catch(() => {})
+          logger.info('Development server produced output').catch(() => {})
         }
         callback()
       },
@@ -167,7 +167,7 @@ export default mergeConfig(userConfig, defineConfig({
           .split('\n')
           .filter((line) => line.trim())
         for (const line of lines) {
-          logger.info(`[SERVER] ${line}`).catch(() => {})
+          logger.info('Development server produced output').catch(() => {})
         }
         callback()
       },

--- a/app/api/tasks/[taskId]/start-sandbox/route.ts
+++ b/app/api/tasks/[taskId]/start-sandbox/route.ts
@@ -263,7 +263,7 @@ export default mergeConfig(userConfig, defineConfig({
                 .split('\n')
                 .filter((line) => line.trim())
               for (const line of lines) {
-                logger.info(`[SERVER] ${line}`).catch(() => {})
+                logger.info('Development server produced output').catch(() => {})
               }
               callback()
             },
@@ -276,7 +276,7 @@ export default mergeConfig(userConfig, defineConfig({
                 .split('\n')
                 .filter((line) => line.trim())
               for (const line of lines) {
-                logger.info(`[SERVER] ${line}`).catch(() => {})
+                logger.info('Development server produced output').catch(() => {})
               }
               callback()
             },

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -466,7 +466,7 @@ async function processTask(
         preDeterminedBranchName: aiBranchName || undefined,
         onProgress: async (progress: number, message: string) => {
           // Use real-time logger for progress updates
-          await logger.updateProgress(progress, message)
+          await logger.updateProgress(progress, 'Sandbox setup in progress')
         },
         onCancellationCheck: async () => {
           // Check if task was stopped

--- a/lib/sandbox/agents/claude.ts
+++ b/lib/sandbox/agents/claude.ts
@@ -17,9 +17,9 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   const redactedCommand = redactSensitiveInfo(fullCommand)
 
   // Log to both local logs and database if logger is provided
-  await logger.command(redactedCommand)
+  await logger.command('Running project command')
   if (logger) {
-    await logger.command(redactedCommand)
+    await logger.command('Running project command')
   }
 
   const result = await runInProject(sandbox, command, args)
@@ -27,17 +27,17 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   // Only try to access properties if result is valid
   if (result && result.output && result.output.trim()) {
     const redactedOutput = redactSensitiveInfo(result.output.trim())
-    await logger.info(redactedOutput)
+    await logger.info('Command produced output')
     if (logger) {
-      await logger.info(redactedOutput)
+      await logger.info('Command produced output')
     }
   }
 
   if (result && !result.success && result.error) {
     const redactedError = redactSensitiveInfo(result.error)
-    await logger.error(redactedError)
+    await logger.error('Command failed')
     if (logger) {
-      await logger.error(redactedError)
+      await logger.error('Command failed')
     }
   }
 
@@ -300,7 +300,7 @@ export async function executeClaudeInSandbox(
 
     // Log the command we're about to execute (with redacted API key)
     const redactedCommand = fullCommand.replace(aiGatewayKey, '[REDACTED]')
-    await logger.command(redactedCommand)
+    await logger.command('Running Claude CLI')
 
     // Set up streaming output capture if we have an agent message
     let capturedOutput = ''

--- a/lib/sandbox/agents/codex.ts
+++ b/lib/sandbox/agents/codex.ts
@@ -9,17 +9,16 @@ type Connector = typeof connectors.$inferSelect
 
 // Helper function to run command and log it in project directory
 async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[], logger: TaskLogger) {
-  const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
-  await logger.command(redactSensitiveInfo(fullCommand))
+  await logger.command('Running project command')
 
   const result = await runInProject(sandbox, command, args)
 
   if (result.output && result.output.trim()) {
-    await logger.info(redactSensitiveInfo(result.output.trim()))
+    await logger.info('Command produced output')
   }
 
   if (!result.success && result.error) {
-    await logger.error(redactSensitiveInfo(result.error))
+    await logger.error('Command failed')
   }
 
   return result
@@ -94,7 +93,7 @@ export async function executeCodexInSandbox(
       const errorMsg = `Invalid API key format. Expected to start with "sk-" (OpenAI) or "vck_" (Vercel), but got: "${apiKey?.substring(0, 15) || 'undefined'}"`
 
       if (logger) {
-        await logger.error(errorMsg)
+        await logger.error('Codex CLI authentication failed')
       }
       return {
         success: false,
@@ -293,13 +292,11 @@ url = "${server.baseUrl}"
 
     const logCommand = `${codexCommand} "${instruction}"`
 
-    await logger.command(logCommand)
+    await logger.command('Running Codex CLI')
     if (logger) {
-      await logger.command(logCommand)
+      await logger.command('Running Codex CLI')
       const providerName = isVercelKey ? 'Vercel AI Gateway' : 'OpenAI API'
-      await logger.info(
-        `Executing Codex with model ${modelToUse} via ${providerName} and bypassed sandbox restrictions`,
-      )
+      await logger.info('Executing Codex CLI')
     }
 
     // Use the same pattern as other working agents (Claude, etc.)
@@ -313,17 +310,17 @@ url = "${server.baseUrl}"
     // Log the output and error results (similar to Claude and Cursor)
     if (result.output && result.output.trim()) {
       const redactedOutput = redactSensitiveInfo(result.output.trim())
-      await logger.info(redactedOutput)
+      await logger.info('Codex CLI produced output')
       if (logger) {
-        await logger.info(redactedOutput)
+        await logger.info('Codex CLI produced output')
       }
     }
 
     if (!result.success && result.error && result.error.trim()) {
       const redactedError = redactSensitiveInfo(result.error.trim())
-      await logger.error(redactedError)
+      await logger.error('Codex CLI produced an error')
       if (logger) {
-        await logger.error(redactedError)
+        await logger.error('Codex CLI produced an error')
       }
     }
 

--- a/lib/sandbox/agents/copilot.ts
+++ b/lib/sandbox/agents/copilot.ts
@@ -12,17 +12,16 @@ type Connector = typeof connectors.$inferSelect
 
 // Helper function to run command and collect logs in project directory
 async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[], logger: TaskLogger) {
-  const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
-  await logger.command(redactSensitiveInfo(fullCommand))
+  await logger.command('Running project command')
 
   const result = await runInProject(sandbox, command, args)
 
   if (result.output && result.output.trim()) {
-    await logger.info(redactSensitiveInfo(result.output.trim()))
+    await logger.info('Command produced output')
   }
 
   if (!result.success && result.error) {
-    await logger.error(redactSensitiveInfo(result.error))
+    await logger.error('Command failed')
   }
 
   return result
@@ -64,7 +63,7 @@ export async function executeCopilotInSandbox(
       if (!copilotInstall.success) {
         const errorMsg = 'Failed to install GitHub Copilot CLI'
         if (logger) {
-          await logger.error(errorMsg)
+          await logger.error('GitHub Copilot CLI installation failed')
         }
         return {
           success: false,
@@ -290,7 +289,7 @@ EOF`
     ]
 
     const logCommand = `copilot${modelFlag}${resumeFlag}${additionalMcpConfig} -p "${instruction}" --allow-all-tools --no-color`
-    await logger.command(logCommand)
+    await logger.command('Running GitHub Copilot CLI')
 
     if (logger) {
       await logger.info('Executing GitHub Copilot CLI in non-interactive mode')
@@ -331,13 +330,11 @@ EOF`
 
     // Log the output and error results
     if (result.output && result.output.trim() && !agentMessageId) {
-      const redactedOutput = redactSensitiveInfo(result.output.trim())
-      await logger.info(redactedOutput)
+      await logger.info('GitHub Copilot CLI produced output')
     }
 
     if (result.error && result.error.trim()) {
-      const redactedError = redactSensitiveInfo(result.error)
-      await logger.error(redactedError)
+      await logger.error('GitHub Copilot CLI produced an error')
     }
 
     // Close the pre tag if streaming to database

--- a/lib/sandbox/agents/cursor.ts
+++ b/lib/sandbox/agents/cursor.ts
@@ -12,17 +12,16 @@ type Connector = typeof connectors.$inferSelect
 
 // Helper function to run command in sandbox root (for installation checks)
 async function runAndLogCommandRoot(sandbox: Sandbox, command: string, args: string[], logger: TaskLogger) {
-  const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
-  await logger.command(redactSensitiveInfo(fullCommand))
+  await logger.command('Running setup command')
 
   const result = await runCommandInSandbox(sandbox, command, args)
 
   if (result.output && result.output.trim()) {
-    await logger.info(redactSensitiveInfo(result.output.trim()))
+    await logger.info('Command produced output')
   }
 
   if (!result.success && result.error) {
-    await logger.error(redactSensitiveInfo(result.error))
+    await logger.error('Command failed')
   }
 
   return result
@@ -30,17 +29,16 @@ async function runAndLogCommandRoot(sandbox: Sandbox, command: string, args: str
 
 // Helper function to run command in project directory (for git operations)
 async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[], logger: TaskLogger) {
-  const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
-  await logger.command(redactSensitiveInfo(fullCommand))
+  await logger.command('Running project command')
 
   const result = await runInProject(sandbox, command, args)
 
   if (result.output && result.output.trim()) {
-    await logger.info(redactSensitiveInfo(result.output.trim()))
+    await logger.info('Command produced output')
   }
 
   if (!result.success && result.error) {
-    await logger.error(redactSensitiveInfo(result.error))
+    await logger.error('Command failed')
   }
 
   return result
@@ -114,7 +112,7 @@ export async function executeCursorInSandbox(
       // For now, we'll fail gracefully with a more informative error
       const errorMsg = `Failed to install Cursor CLI: ${cursorInstall.error || 'Installation timed out or failed'}. The Cursor CLI installation script may not be compatible with this sandbox environment.`
       if (logger) {
-        await logger.error(errorMsg)
+        await logger.error('Cursor CLI installation failed')
       }
       return {
         success: false,
@@ -287,7 +285,7 @@ EOF`
     const resumeFlag = isResumed && sessionId ? ` --resume ${sessionId}` : ''
     const logCommand = `cursor-agent -p --force --output-format stream-json${modelFlag}${resumeFlag} "${instruction}"`
     if (logger) {
-      await logger.command(logCommand)
+      await logger.command('Running Cursor CLI')
       if (selectedModel) {
         await logger.info('Executing cursor-agent with model')
       }
@@ -513,12 +511,12 @@ EOF`
     // Skip logging raw output when streaming to database (we've already built clean content there)
     if (result.output && result.output.trim() && !agentMessageId) {
       const redactedOutput = redactSensitiveInfo(result.output.trim())
-      await logger.info(redactedOutput)
+      await logger.info('Cursor CLI produced output')
     }
 
     if (result.error && result.error.trim()) {
       const redactedError = redactSensitiveInfo(result.error)
-      await logger.error(redactedError)
+      await logger.error('Cursor CLI produced an error')
     }
 
     // Cursor CLI execution completed

--- a/lib/sandbox/agents/gemini.ts
+++ b/lib/sandbox/agents/gemini.ts
@@ -12,19 +12,19 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
   const redactedCommand = redactSensitiveInfo(fullCommand)
 
-  await logger.command(redactedCommand)
+  await logger.command('Running project command')
 
   const result = await runInProject(sandbox, command, args)
 
   // Only try to access properties if result is valid
   if (result && result.output && result.output.trim()) {
     const redactedOutput = redactSensitiveInfo(result.output.trim())
-    await logger.info(redactedOutput)
+    await logger.info('Command produced output')
   }
 
   if (result && !result.success && result.error) {
     const redactedError = redactSensitiveInfo(result.error)
-    await logger.error(redactedError)
+    await logger.error('Command failed')
   }
 
   // If result is null/undefined, create a fallback result
@@ -219,7 +219,7 @@ EOF`
     // Log what we're trying to do
     await logger.info('Executing Gemini CLI with authentication')
     const redactedCommand = `gemini ${args.join(' ')} "${instruction.substring(0, 100)}..."`
-    await logger.command(redactedCommand)
+    await logger.command('Running Gemini CLI')
 
     // Build environment variables string for shell command (like other agents)
     const envPrefix = Object.entries(authEnv)
@@ -266,7 +266,7 @@ EOF`
     // Check if result is valid before accessing properties
     if (!result) {
       const errorMsg = 'Gemini CLI execution failed - no result returned'
-      await logger.error(errorMsg)
+      await logger.error('Gemini CLI execution failed')
       return {
         success: false,
         error: errorMsg,
@@ -278,12 +278,12 @@ EOF`
     // Log the output
     if (result.output && result.output.trim()) {
       const redactedOutput = redactSensitiveInfo(result.output.trim())
-      await logger.info(redactedOutput)
+      await logger.info('Gemini CLI produced output')
     }
 
     if (!result.success && result.error) {
       const redactedError = redactSensitiveInfo(result.error)
-      await logger.error(redactedError)
+      await logger.error('Gemini CLI produced an error')
     }
 
     // Log more details for debugging

--- a/lib/sandbox/agents/opencode.ts
+++ b/lib/sandbox/agents/opencode.ts
@@ -12,19 +12,19 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   const fullCommand = args.length > 0 ? `${command} ${args.join(' ')}` : command
   const redactedCommand = redactSensitiveInfo(fullCommand)
 
-  await logger.command(redactedCommand)
+  await logger.command('Running project command')
 
   const result = await runInProject(sandbox, command, args)
 
   // Only try to access properties if result is valid
   if (result && result.output && result.output.trim()) {
     const redactedOutput = redactSensitiveInfo(result.output.trim())
-    await logger.info(redactedOutput)
+    await logger.info('Command produced output')
   }
 
   if (result && !result.success && result.error) {
     const redactedError = redactSensitiveInfo(result.error)
-    await logger.error(redactedError)
+    await logger.error('Command failed')
   }
 
   // If result is null/undefined, create a fallback result
@@ -59,7 +59,7 @@ export async function executeOpenCodeInSandbox(
     // Check if we have required environment variables for OpenCode
     if (!process.env.OPENAI_API_KEY && !process.env.ANTHROPIC_API_KEY) {
       const errorMsg = 'OpenAI API key or Anthropic API key is required for OpenCode agent'
-      await logger.error(errorMsg)
+      await logger.error('OpenCode agent is missing API credentials')
       return {
         success: false,
         error: errorMsg,
@@ -347,9 +347,9 @@ EOF`
 
     // Log the command we're about to execute (with redacted API keys)
     const redactedCommand = fullCommand.replace(/API_KEY="[^"]*"/g, 'API_KEY="[REDACTED]"')
-    await logger.command(redactedCommand)
+    await logger.command('Running OpenCode CLI')
     if (logger) {
-      await logger.command(redactedCommand)
+      await logger.command('Running OpenCode CLI')
     }
 
     // Execute OpenCode run command
@@ -360,15 +360,15 @@ EOF`
 
     // Log the output
     if (stdout && stdout.trim()) {
-      await logger.info(redactSensitiveInfo(stdout.trim()))
+      await logger.info('OpenCode CLI produced output')
       if (logger) {
-        await logger.info(redactSensitiveInfo(stdout.trim()))
+        await logger.info('OpenCode CLI produced output')
       }
     }
     if (stderr && stderr.trim()) {
-      await logger.error(redactSensitiveInfo(stderr.trim()))
+      await logger.error('OpenCode CLI produced an error')
       if (logger) {
-        await logger.error(redactSensitiveInfo(stderr.trim()))
+        await logger.error('OpenCode CLI produced an error')
       }
     }
 
@@ -393,7 +393,7 @@ EOF`
     if (executeResult.success || executeResult.exitCode === 0) {
       const successMsg = `OpenCode executed successfully${hasChanges ? ' (Changes detected)' : ' (No changes made)'}`
       if (logger) {
-        await logger.success(successMsg)
+        await logger.success('OpenCode CLI completed successfully')
       }
 
       // If there are changes, log what was changed
@@ -416,7 +416,7 @@ EOF`
     } else {
       const errorMsg = `OpenCode failed (exit code ${executeResult.exitCode}): ${stderr || stdout || 'No error message'}`
       if (logger) {
-        await logger.error(errorMsg)
+        await logger.error('OpenCode CLI failed')
       }
 
       return {
@@ -433,7 +433,7 @@ EOF`
     console.error('OpenCode execution error:', error)
 
     if (logger) {
-      await logger.error(errorMessage)
+      await logger.error('OpenCode CLI execution failed')
     }
 
     return {

--- a/lib/sandbox/creation.ts
+++ b/lib/sandbox/creation.ts
@@ -18,9 +18,7 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   }
 
   const fullCommand = args.length > 0 ? `${command} ${args.map(escapeArg).join(' ')}` : command
-  const redactedCommand = redactSensitiveInfo(fullCommand)
-
-  await logger.command(redactedCommand)
+  await logger.command('Running sandbox setup command')
 
   let result
   if (cwd) {
@@ -32,13 +30,11 @@ async function runAndLogCommand(sandbox: Sandbox, command: string, args: string[
   }
 
   if (result && result.output && result.output.trim()) {
-    const redactedOutput = redactSensitiveInfo(result.output.trim())
-    await logger.info(redactedOutput)
+    await logger.info('Sandbox setup command produced output')
   }
 
   if (result && !result.success && result.error) {
-    const redactedError = redactSensitiveInfo(result.error)
-    await logger.error(redactedError)
+    await logger.error('Sandbox setup command failed')
   }
 
   return result
@@ -149,8 +145,8 @@ export async function createSandbox(config: SandboxConfig, logger: TaskLogger): 
 
       // Check if this is a timeout error
       if (errorMessage?.includes('timeout') || errorCode === 'ETIMEDOUT' || errorName === 'TimeoutError') {
-        await logger.error(`Sandbox creation timed out after 5 minutes`)
-        await logger.error(`This usually happens when the repository is large or has many dependencies`)
+        await logger.error('Sandbox creation timed out')
+        await logger.error('Repository may be large or have many dependencies')
         throw new Error('Sandbox creation timed out. Try with a smaller repository or fewer dependencies.')
       }
 
@@ -426,7 +422,7 @@ fi
                   .split('\n')
                   .filter((line) => line.trim())
                 for (const line of lines) {
-                  logger.info(`[SERVER] ${line}`).catch(() => {})
+                  logger.info('Development server produced output').catch(() => {})
                 }
                 callback()
               },
@@ -439,7 +435,7 @@ fi
                   .split('\n')
                   .filter((line) => line.trim())
                 for (const line of lines) {
-                  logger.info(`[SERVER] ${line}`).catch(() => {})
+                  logger.info('Development server produced output').catch(() => {})
                 }
                 callback()
               },

--- a/lib/sandbox/git.ts
+++ b/lib/sandbox/git.ts
@@ -25,7 +25,7 @@ export async function pushChangesToBranch(
       await logger.info('Failed to add changes')
       if (addResult.error) {
         console.error('Git add error details:', addResult.error)
-        await logger.error(`Git add failed: ${addResult.error}`)
+        await logger.error('Git add failed')
       }
       return { success: false }
     }
@@ -37,7 +37,7 @@ export async function pushChangesToBranch(
       await logger.info('Failed to commit changes')
       if (commitResult.error) {
         console.error('Commit error details:', commitResult.error)
-        await logger.error(`Commit failed: ${commitResult.error}`)
+        await logger.error('Commit failed')
       }
       return { success: false }
     }

--- a/lib/sandbox/package-manager.ts
+++ b/lib/sandbox/package-manager.ts
@@ -35,7 +35,6 @@ export async function installDependencies(
   logger: TaskLogger,
 ): Promise<{ success: boolean; error?: string }> {
   let installCommand: string[]
-  let logMessage: string
 
   switch (packageManager) {
     case 'pnpm':
@@ -48,19 +47,16 @@ export async function installDependencies(
       }
 
       installCommand = ['pnpm', 'install', '--frozen-lockfile']
-      logMessage = 'Attempting pnpm install'
       break
     case 'yarn':
       installCommand = ['yarn', 'install', '--frozen-lockfile']
-      logMessage = 'Attempting yarn install'
       break
     case 'npm':
       installCommand = ['npm', 'install', '--no-audit', '--no-fund']
-      logMessage = 'Attempting npm install'
       break
   }
 
-  await logger.info(logMessage)
+  await logger.info('Installing Node.js dependencies')
 
   const installResult = await runInProject(sandbox, installCommand[0], installCommand.slice(1))
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type-check": "tsc --noEmit",
     "format": "prettier --write \"**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx}\"",
+    "check:task-logs": "tsx scripts/check-task-logger-static.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",

--- a/scripts/check-task-logger-static.ts
+++ b/scripts/check-task-logger-static.ts
@@ -1,0 +1,98 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const ROOTS = ['app', 'lib']
+const LOGGER_METHODS = ['info', 'error', 'success', 'command', 'updateStatus', 'updateProgress']
+
+function walk(dir: string): string[] {
+  const entries = readdirSync(dir)
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry)
+    const stats = statSync(fullPath)
+    if (stats.isDirectory()) {
+      files.push(...walk(fullPath))
+    } else if (fullPath.endsWith('.ts') || fullPath.endsWith('.tsx')) {
+      files.push(fullPath)
+    }
+  }
+
+  return files
+}
+
+function callArguments(source: string, start: number): string[] {
+  const args: string[] = []
+  let current = ''
+  let depth = 0
+  let quote: string | null = null
+
+  for (let i = start; i < source.length; i++) {
+    const char = source[i]
+    const previous = source[i - 1]
+
+    if (quote) {
+      if (char === quote && previous !== '\\') quote = null
+      current += char
+      continue
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char
+      current += char
+      continue
+    }
+
+    if (char === '(') {
+      depth++
+      current += char
+      continue
+    }
+    if (char === ')') {
+      if (depth === 0) {
+        if (current.trim()) args.push(current.trim())
+        return args
+      }
+      depth--
+      current += char
+      continue
+    }
+    if (char === ',' && depth === 0) {
+      args.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  if (current.trim()) args.push(current.trim())
+  return args
+}
+
+function isStringLiteral(argument: string | undefined): boolean {
+  return !!argument && (argument.startsWith("'") || argument.startsWith('"'))
+}
+
+const violations: string[] = []
+
+for (const root of ROOTS) {
+  for (const file of walk(root)) {
+    const source = readFileSync(file, 'utf8')
+    for (const method of LOGGER_METHODS) {
+      const pattern = new RegExp(`logger\\.${method}\\(`, 'g')
+      for (const match of source.matchAll(pattern)) {
+        const args = callArguments(source, (match.index ?? 0) + match[0].length)
+        const messageArg = method === 'updateProgress' ? args[1] : args[0]
+        if (!isStringLiteral(messageArg)) {
+          violations.push(`${file}: logger.${method} uses a non-literal message argument`)
+        }
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(violations.join('\n'))
+  process.exit(1)
+}


### PR DESCRIPTION
## Summary
- replace user-facing TaskLogger command/output/error messages with fixed phrases across sandbox setup and agent execution paths
- keep detailed command/output data out of task logs while preserving return values and server-side console diagnostics
- add `pnpm check:task-logs` to catch future non-literal TaskLogger messages

Closes #58.

## Verification
- `pnpm check:task-logs`
- `pnpm type-check`