### PR TITLE
Upgrade AI SDK to v7 with Vercel OIDC authentication support

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -46,4 +46,3 @@ jobs:
 
       - name: Run build
         run: pnpm build
-

--- a/lib/utils/branch-name-generator.ts
+++ b/lib/utils/branch-name-generator.ts
@@ -10,10 +10,6 @@ export interface BranchNameOptions {
 export async function generateBranchName(options: BranchNameOptions): Promise<string> {
   const { description, repoName, context } = options
 
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    throw new Error('AI_GATEWAY_API_KEY environment variable is required')
-  }
-
   // Create the prompt for branch name generation
   const prompt = `Generate a concise, descriptive Git branch name for the following task:
 
@@ -37,7 +33,7 @@ Examples of good branch names:
 Return ONLY the branch name, nothing else.`
 
   try {
-    // Generate branch name using AI SDK 5 with AI Gateway
+    // Generate branch name using AI SDK 7 with AI Gateway
     const result = await generateText({
       model: 'openai/gpt-5-nano',
       prompt,

--- a/lib/utils/commit-message-generator.ts
+++ b/lib/utils/commit-message-generator.ts
@@ -9,10 +9,6 @@ export interface CommitMessageOptions {
 export async function generateCommitMessage(options: CommitMessageOptions): Promise<string> {
   const { description, repoName, context } = options
 
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    throw new Error('AI_GATEWAY_API_KEY environment variable is required')
-  }
-
   // Create the prompt for commit message generation
   const prompt = `Generate a concise, descriptive Git commit message for the following change:
 
@@ -38,7 +34,7 @@ Examples of good commit messages:
 Return ONLY the commit message, nothing else.`
 
   try {
-    // Generate commit message using AI SDK 5 with AI Gateway
+    // Generate commit message using AI SDK 7 with AI Gateway
     const result = await generateText({
       model: 'openai/gpt-5-nano',
       prompt,

--- a/lib/utils/title-generator.ts
+++ b/lib/utils/title-generator.ts
@@ -9,10 +9,6 @@ export interface TitleGenerationOptions {
 export async function generateTaskTitle(options: TitleGenerationOptions): Promise<string> {
   const { prompt, repoName, context } = options
 
-  if (!process.env.AI_GATEWAY_API_KEY) {
-    throw new Error('AI_GATEWAY_API_KEY environment variable is required')
-  }
-
   // Create the prompt for title generation
   const systemPrompt = `Generate a concise, descriptive title for the following task:
 
@@ -36,7 +32,7 @@ Examples of good titles:
 Return ONLY the title, nothing else.`
 
   try {
-    // Generate title using AI SDK 5 with AI Gateway
+    // Generate title using AI SDK 7 with AI Gateway
     const result = await generateText({
       model: 'openai/gpt-5-nano',
       prompt: systemPrompt,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "coding-agent-template",
   "version": "2.0.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev --webpack",
     "build": "next build --turbopack",
@@ -42,7 +45,7 @@
     "@vercel/sandbox": "^0.0.21",
     "@vercel/sdk": "^1.18.7",
     "@vercel/speed-insights": "^1.3.1",
-    "ai": "5.0.51",
+    "ai": "7.0.34",
     "arctic": "^3.7.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1(next@16.0.10(@babel/core@7.28.6)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       ai:
-        specifier: 5.0.51
-        version: 5.0.51(zod@4.3.6)
+        specifier: 7.0.34
+        version: 7.0.34(zod@4.3.6)
       arctic:
         specifier: ^3.7.0
         version: 3.7.0
@@ -210,21 +210,21 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@1.0.28':
-    resolution: {integrity: sha512-e9RKgWVDYHsd4UkKCgKQpK+nxLSDydN18yXctzgNlmf2R7BR+HqUsTKJdZT6ArSoXBWBGhyZss0cJJnpm6YVfw==}
-    engines: {node: '>=18'}
+  '@ai-sdk/gateway@4.0.26':
+    resolution: {integrity: sha512-b/nc3COKtk8IxzgcCi418IoZFky/Bw+Jg8+J0/SBBnu/mOXA4bkIKCu81coEtJAWuH2g5Fvvsa0ar7EpmzNWTw==}
+    engines: {node: '>=22'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.9':
-    resolution: {integrity: sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
+    engines: {node: '>=22'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
-    engines: {node: '>=18'}
+  '@ai-sdk/provider@4.0.3':
+    resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2149,6 +2149,10 @@ packages:
     resolution: {integrity: sha512-59PBFx3T+k5hLTEWa3ggiMpGRz1OVvl9eN8SUai+A43IsqiOuAe7qPBf+cray/Fj6mkgnxm/D7IAtjc8zSHi7g==}
     engines: {node: '>= 18'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vercel/sandbox@0.0.21':
     resolution: {integrity: sha512-j6nAUQyuw6znVaZGd7yI0nab1EWhEtIZPnTXvpDatJ2SObodYZOz5hGoLjCopAuhQBC7vOngbZ1bwP6HxtB5+g==}
 
@@ -2185,6 +2189,9 @@ packages:
   '@vue/shared@3.5.27':
     resolution: {integrity: sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -2199,11 +2206,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ai@5.0.51:
-    resolution: {integrity: sha512-ToKW099QWUJNqePZbWGg8FSfxTxS3UN9U6yCla8rYdW0EBTDNPnpRwK1N6ER9TfV+dFtdUu+ZgKSlhQnEThriQ==}
-    engines: {node: '>=18'}
+  ai@7.0.34:
+    resolution: {integrity: sha512-jDqclWYqPGFKcUG4CQiKcBiwi5XqVMqvYy6eJdujVpvE1SDoB6j7RtjrGYz3Bn5B1dzTj1StAlrOebY//WK9/Q==}
+    engines: {node: '>=22'}
     peerDependencies:
-      zod: ^3.25.76 || ^4
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -3026,6 +3033,10 @@ packages:
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
@@ -4850,20 +4861,22 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@1.0.28(zod@4.3.6)':
+  '@ai-sdk/gateway@4.0.26(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
+      '@vercel/oidc': 3.2.0
       zod: 4.3.6
 
-  '@ai-sdk/provider-utils@3.0.9(zod@4.3.6)':
+  '@ai-sdk/provider-utils@5.0.12(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider@4.0.3':
     dependencies:
       json-schema: 0.4.0
 
@@ -6600,6 +6613,8 @@ snapshots:
       '@types/ms': 2.1.0
       ms: 2.1.3
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vercel/sandbox@0.0.21':
     dependencies:
       '@vercel/oidc': 2.0.2
@@ -6633,6 +6648,8 @@ snapshots:
 
   '@vue/shared@3.5.27': {}
 
+  '@workflow/serde@4.1.0': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -6644,12 +6661,11 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ai@5.0.51(zod@4.3.6):
+  ai@7.0.34(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 1.0.28(zod@4.3.6)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.9(zod@4.3.6)
-      '@opentelemetry/api': 1.9.0
+      '@ai-sdk/gateway': 4.0.26(zod@4.3.6)
+      '@ai-sdk/provider': 4.0.3
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.3.6)
       zod: 4.3.6
 
   ajv-formats@3.0.1(ajv@8.17.1):
@@ -7641,6 +7657,8 @@ snapshots:
       - bare-abort-controller
 
   eventsource-parser@3.0.6: {}
+
+  eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
     dependencies:


### PR DESCRIPTION
## Summary

- upgrade `ai` from 5.0.51 to 7.0.34
- require Node.js 22 locally and in PR checks, matching AI SDK v7's runtime requirement
- remove the three `AI_GATEWAY_API_KEY`-only preflight checks so AI Gateway can use Vercel's request-scoped OIDC authentication
- update the three stale AI SDK version comments

This deliberately uses 7.0.34 rather than the hours-old 7.0.42 because the repository's dependency release-age policy rejected the latter. The policy was not weakened.

## Evidence

Executed on this branch:

- `pnpm install --frozen-lockfile` — passed with pnpm 9.15.9
- `pnpm type-check` — passed
- `pnpm lint` — passed with 0 errors and 24 existing warnings
- `pnpm format:check` — passed
- `pnpm build` — passed; existing `shiki` externalization and baseline-browser-data warnings remain
- live AI Gateway smoke test with `AI_GATEWAY_API_KEY` explicitly removed and an existing Vercel OIDC credential — title generation, branch-name generation, and commit-message generation all returned valid results

Observed live results:

```json
{
  "auth": "OIDC only",
  "title": "Add vercel sandbox browser test for create commit push",
  "branch": "feature/browser-smoke-test-vercel-sandbox-<random suffix>",
  "commit": "Add browser smoke-test to verify create, commit and push vercel sandbox"
}
```

References:

- AI Gateway authentication: https://vercel.com/docs/ai-gateway/authentication-and-byok
- Vercel OIDC runtime token behavior: https://vercel.com/docs/oidc/reference

## Scope boundary

This PR does **not** remove PostgreSQL/Drizzle, redesign persistence, change OAuth, replace agent harnesses, or include the broader first-run experiments. Those are being isolated and require their own behavioral evidence before review.
